### PR TITLE
Fix Flake to Run Universally

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,11 @@
 
             nativeBuildInputs = [ pkgs.makeWrapper ];
 
-            buildInputs = [ lua-with-pkgs ];
+            buildInputs = [
+              lua-with-pkgs
+              pkgs.gobject-introspection
+              pkgs.cairo
+            ];
 
             installPhase = ''
               runHook preInstall

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,8 @@
             installPhase = ''
               runHook preInstall
               install -Dm755 main.lua $out/bin/wallpaper-generator
-              install -Dm755 -d generators $out/bin/generators
+              install -Dm755 -t $out/bin/generators generators/*.lua
+              install -Dm755 -t $out/bin/generators/lib generators/lib/*.lua
 
               wrapProgram $out/bin/wallpaper-generator \
                 --set LUA_CPATH "${


### PR DESCRIPTION
Add cairo and gobject-inspection as buildInputs dependencies. These are
required to be able to run the application.

Other fixes required, as currently "generators" is called from current working directory instead of runtime directory. This at least gets `nix run` to work on my machine for now.

Addresses #6 