### PR TITLE
add wallpaper nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,19 @@
             };
           };
 
+          wallpaper = pkgs.callPackage
+            ({ function ? "batman", width ? 3840, height ? 2160, extraArguments ? "", ... }:
+              pkgs.stdenv.mkDerivation {
+                name = "wallpaper";
+                dontUnpack = true;
+                phases = [ "installPhase" ];
+                installPhase = ''
+                  mkdir $out
+                  ${self.packages.${system}.wp-gen}/bin/wallpaper-generator ${function} --width ${toString width} --height ${toString height} ${extraArguments} -o $out/wallpaper.png
+                '';
+              })
+            { };
+
         };
         defaultPackage = packages.wp-gen;
       });


### PR DESCRIPTION
Adding this package, simplifies using the outputs of wp-gen in NixOS configurations.

By using overrides, it can be configured:

```ǹix
(wallpaper.override { function = "prisma"; });
```
